### PR TITLE
`KeyMapping` Mini-Hotfix

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -96,7 +96,7 @@ if Config.Command and Config.KeyMapping.Enabled then
 end
 
 if Config.KeyMapping.Enabled then
-    RegisterKeyMapping('repair_bench', Config.KeyMapping.Description, 'keyboard', Config.Keymapping.Keybind)
+    RegisterKeyMapping('repair_bench', Config.KeyMapping.Description, 'keyboard', Config.KeyMapping.Keybind)
 end
 
 RegisterNetEvent('alv_repairtable:placeTable', function()


### PR DESCRIPTION
SCRIPT ERROR: alv_repairtable/client/client.lua: attempt to index a nil value (field 'Keymapping') (Line: 99)